### PR TITLE
Expose BNO086 pin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# HF - BNO08x
+#HF - BNO08x
 Hardware Agnostic BNO08x library - as used in the HardFOC-V1 controller
 
-# BNO085 C++ Sensor Library 🚀
+#BNO085 C++ Sensor Library 🚀
 
 > **Full-stack, hardware-agnostic, zero-thread driver for Hillcrest / CEVA BNO08x**  
 
@@ -40,6 +40,7 @@ Hardware Agnostic BNO08x library - as used in the HardFOC-V1 controller
 | 🔁 **Auto Re-Sync** | Detects sensor resets & seamlessly re-enables all configured features. |
 | 🧮 **Float-Friendly API** | Returns handy structs (`Vector3`, `Quaternion`, `SensorEvent`) with SI units. |
 | 📚 **GPLv3 & Apache-2.0** | C++ wrapper under GPLv3; CEVA SH-2 backend under Apache 2.0 – both included. |
+| 🔌 **Pin Control API** | Optional helpers let you drive RSTN/BOOTN/WAKE via your transport for resets or DFU. |
 
 ---
 
@@ -74,10 +75,10 @@ for normal use. The other folders provide optional examples and helper code.
 Getting Started 🏁
 
 ```bash
-# Clone wherever you keep libs 📂
+#Clone wherever you keep libs 📂
 git clone --depth=1 https://github.com/yourOrg/bno085-cpp.git libs/bno085
 
-# Add the .cpp/.h files plus sh2/* to your project build.
+#Add the.cpp /.h files plus sh2/* to your project build.
 # CMake example ⤵️
 add_subdirectory(libs/bno085)
 target_link_libraries(myApp PRIVATE bno085)
@@ -222,6 +223,7 @@ walk‑through of the process.
 - **Accuracy**: `event.accuracy` (0–3) indicates calibration status. Wait for `3` before trusting the heading.
 - **DFU Mode**: hold **BOOTN** low during reset to enter the bootloader for firmware updates.
 - **Power Saving**: disable unused reports to save around 20 mA.
+- **Pin Helpers**: `hardwareReset()`, `setBootPin()` and `setWakePin()` expose RSTN/BOOTN/WAKE control when wired.
 
 ## Contributing 🤝
 

--- a/src/BNO085.cpp
+++ b/src/BNO085.cpp
@@ -248,3 +248,25 @@ bool BNO085::configure(BNO085Sensor sensor, uint32_t intervalUs,
   }
   return true;
 }
+
+/** Toggle the hardware reset line if implemented. */
+void BNO085::hardwareReset(uint32_t lowMs) {
+  if (!io)
+    return;
+  io->setReset(false);
+  io->delay(lowMs);
+  io->setReset(true);
+  io->delay(50); // allow sensor to boot
+}
+
+/** Drive the BOOTN pin. */
+void BNO085::setBootPin(bool state) {
+  if (io)
+    io->setBoot(state);
+}
+
+/** Drive the WAKE pin. */
+void BNO085::setWakePin(bool state) {
+  if (io)
+    io->setWake(state);
+}

--- a/src/BNO085.hpp
+++ b/src/BNO085.hpp
@@ -160,6 +160,20 @@ public:
   /** Retrieve the last error code returned by the SH-2 driver. */
   int getLastError() const { return lastError; }
 
+  /**
+   * @brief Toggle the sensor's hardware reset line if available.
+   *
+   * Drives RSTN low for the specified time then releases it. Platforms not
+   * providing the pin may leave the implementation empty.
+   */
+  void hardwareReset(uint32_t lowMs = 2);
+
+  /** Set the BOOTN pin level (used to enter DFU). */
+  void setBootPin(bool state);
+
+  /** Control the WAKE pin in SPI mode. */
+  void setWakePin(bool state);
+
 private:
   /**
    * @brief Internal wrapper converting ::IBNO085Transport to the SH-2 HAL.

--- a/src/BNO085_Transport.hpp
+++ b/src/BNO085_Transport.hpp
@@ -63,4 +63,28 @@ public:
    * The transport implementation must provide this in microseconds.
    */
   virtual uint32_t getTimeUs() = 0;
+
+  /**
+   * @brief Control the hardware reset (RSTN) pin.
+   *
+   * The default implementation does nothing. Platforms that connect the
+   * sensor's RSTN pin can override this to assert or release reset.
+   */
+  virtual void setReset(bool state) {}
+
+  /**
+   * @brief Control the BOOTN pin used to enter DFU mode.
+   *
+   * Driving BOOTN low during a reset places the device in the bootloader.
+   * Implementations may leave this empty if the pin is not wired.
+   */
+  virtual void setBoot(bool state) {}
+
+  /**
+   * @brief Control the WAKE pin (SPI mode only).
+   *
+   * When using SPI, pulling WAKE low brings the device out of suspend. Not
+   * all designs expose this pin, so the default does nothing.
+   */
+  virtual void setWake(bool state) {}
 };


### PR DESCRIPTION
## Summary
- add pin control hooks to the transport interface
- expose helpers in `BNO085` for reset/boot/wake
- document new APIs in README

## Testing
- `clang-format -i src/BNO085_Transport.hpp src/BNO085.hpp src/BNO085.cpp README.md`
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5c4d5048328a5051cf645c7d150