### PR TITLE
Fix CI build for esp32c6

### DIFF
--- a/components/bno08x/idf_component.yml
+++ b/components/bno08x/idf_component.yml
@@ -3,6 +3,7 @@ maintainers:
   - "HardFOC"
 targets:
   - esp32
+  - esp32c6
 description: Hardware-agnostic BNO08x driver component
 url: https://example.com
 repository: https://example.com/hf-bno08x


### PR DESCRIPTION
## Summary
- allow esp32c6 in `idf_component.yml`
