### PR TITLE
Fix CI build by copying example helpers

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -58,6 +58,8 @@ jobs:
             sed -i "s|../../components|../components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
             rm -rf ${{ env.BUILD_PATH }}/main
             cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            # Copy shared example helpers
+            cp -r examples/common ${{ env.BUILD_PATH }}/common
             idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
             idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
             idf.py -C ${{ env.BUILD_PATH }} size --format json > ${{ env.BUILD_PATH }}/build/size.json


### PR DESCRIPTION
## Summary
- update ESP-IDF build step in CI to copy `examples/common`

## Testing
- `clang-format --dry-run --Werror src/*.hpp src/*.cpp examples/esp32/main/*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684e099faabc8328a3da94f06b8e2dea