### PR TITLE
Add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
+      - name: Build documentation
+        run: doxygen Doxyfile
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/html
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and upload documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e129ec05483288efbe38ad1f41f44