### PR TITLE
Fix C/C++ RVC HAL integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,16 +205,17 @@ Some Hillcrest/CEVA sensors offer a simplified "Robot Vacuum Cleaner" (RVC) mode
 that streams yaw/pitch/roll and linear acceleration over UART without any SH‑2
 commands.  If your application only needs basic orientation data and you want to
 avoid the overhead of the full protocol, this mode can be very handy.  The
-`src/rvc` folder contains a small decoder library, the `IRvcHal` interface and a
-lightweight `Rvc` C++ wrapper.  The high level `BNO085` class also exposes helper
+`src/rvc` folder contains a small decoder library, the `IRvcHal` interface
+(`RvcHalC_t` for C) and a lightweight `Rvc` C++ wrapper.  The high level `BNO085` class also exposes helper
 methods so you can handle RVC data without using the separate wrapper.
 
 Entering RVC mode is typically done via boot‑time pin strapping or a vendor
 command.  Once enabled the sensor continuously outputs 19‑byte frames at a fixed
-baud rate (usually 115200 bps).  Implement `IRvcHal` to read bytes from the
-serial port and either create a dedicated `Rvc` instance or call `beginRvc()` on
-`BNO085`.  Register a callback with `setRvcCallback()` and call `serviceRvc()` in
-your loop to parse incoming frames.
+baud rate (usually 115200 bps).  Implement `IRvcHal` (or fill out a `RvcHalC_t`
+struct from C) to read bytes from the serial port and either create a dedicated
+`Rvc` instance or call `beginRvc()` on `BNO085`.  Register a callback with
+`setRvcCallback()` and call `serviceRvc()` in your loop to parse incoming
+frames.
 See [`src/rvc/README.md`](src/rvc/README.md) for full details and a complete
 example. A minimal program is provided in `examples/RVC_Basic.cpp`.
 

--- a/src/rvc/README.md
+++ b/src/rvc/README.md
@@ -52,8 +52,9 @@ Use these to interpret how the sensor believes it is moving and any requested
 constraints from the host.
 
 ## Using the library
-1. Implement `IRvcHal` to read bytes from the UART connected to the sensor. An
-   example for the ESP32‑C6 is provided in `RvcHalEsp32C6.hpp`.
+1. Implement `IRvcHal` (or populate a `RvcHalC_t` struct) to read bytes from the
+   UART connected to the sensor. An example for the ESP32‑C6 is provided in
+   `RvcHalEsp32C6.hpp`.
 2. Create a `Rvc` object with your HAL and register a callback with
    `Rvc::setCallback()`.
 3. Call `Rvc::open()` and then periodically `Rvc::service()` to decode frames.

--- a/src/rvc/Rvc.hpp
+++ b/src/rvc/Rvc.hpp
@@ -15,8 +15,13 @@ public:
         rvc_init(hal);
     }
 
+    /// Construct with a C style HAL.
+    explicit Rvc(RvcHalC_t *hal) { rvc_init_c(hal); }
+
     /// Change the HAL after construction.
     void setHal(IRvcHal *hal) { rvc_init(hal); }
+    /// Change the HAL using a C style implementation.
+    void setHal(RvcHalC_t *hal) { rvc_init_c(hal); }
 
     /// Register a callback for received frames.
     int setCallback(rvc_Callback_t *cb, void *cookie = nullptr) {

--- a/src/rvc/rvc.h
+++ b/src/rvc/rvc.h
@@ -23,6 +23,8 @@
 #ifdef __cplusplus
 class IRvcHal;
 extern "C" {
+#else
+typedef struct IRvcHal IRvcHal; /**< Opaque HAL handle for C code */
 #endif
 
 // return status values
@@ -47,9 +49,6 @@ extern "C" {
 #define MR_URGENT_STATIONARY (4)
 #define MR_TIMER_STATIONARY (5)
 
-// Use integers as references to RVC HAL instances.
-// (Maybe change to a structure later?)
-typedef int RvcHal_t;
 
 typedef struct rvc_SensorEvent_s {
   uint8_t index;
@@ -77,12 +76,22 @@ typedef struct rvc_SensorValue_s {
   uint64_t timestamp_uS;
 } rvc_SensorValue_t;
 
+/** C style HAL using function pointers. */
+typedef struct RvcHalC_s {
+  void *ctx;                                         /**< User supplied context */
+  int (*open)(void *ctx);                            /**< Open the interface */
+  void (*close)(void *ctx);                          /**< Close and cleanup */
+  int (*read)(void *ctx, rvc_SensorEvent_t *event);  /**< Read a frame */
+} RvcHalC_t;
+
 typedef void rvc_Callback_t(void *cookie, rvc_SensorEvent_t *pEvent);
 
 // Public API calls used by demo_rvc.c
 
 // Initialize the RVC sensor hub module with a HAL implementation
 int rvc_init(IRvcHal *hal);
+// Initialize using a C style HAL implementation
+int rvc_init_c(RvcHalC_t *hal);
 
 // Application registers callback function to receive sensor events
 int rvc_setCallback(rvc_Callback_t *callback, void *cookie);


### PR DESCRIPTION
## Summary
- expose IRvcHal as opaque struct for C builds
- provide C-style RVC HAL (`RvcHalC_t`) and `rvc_init_c`
- add adapter implementation in rvc.cpp
- support new C HAL in `Rvc` wrapper
- update documentation for new API
