### PR TITLE
Fix build on IDF 5

### DIFF
--- a/src/app/rvc_hal.c
+++ b/src/app/rvc_hal.c
@@ -2,6 +2,7 @@
 #include <driver/uart.h>
 #include <driver/gpio.h>
 #include "esp_timer.h"
+#include <esp_rom_sys.h>
 #include <string.h>
 
 #define UART_PORT UART_NUM_0
@@ -54,7 +55,7 @@ static int hal_open(void *ctx)
     uart_driver_install(UART_PORT, BUF_SIZE, 0, 0, NULL, 0);
     gpio_set_level(PIN_BOOT, 1);
     gpio_set_level(PIN_RST, 0);
-    ets_delay_us(10000);
+    esp_rom_delay_us(10000);
     gpio_set_level(PIN_RST, 1);
     len = 0;
     ready = false;

--- a/src/rvc/RvcHalEsp32C6.hpp
+++ b/src/rvc/RvcHalEsp32C6.hpp
@@ -3,6 +3,7 @@
 #include "driver/gpio.h"
 #include "driver/uart.h"
 #include "esp_timer.h"
+#include <esp_rom_sys.h>
 #include <cstring>
 
 /**
@@ -29,7 +30,7 @@ public:
     uart_driver_install(_port, BUF_SIZE, 0, 0, nullptr, 0);
     gpio_set_level(_boot, 1);
     gpio_set_level(_rst, 0);
-    ets_delay_us(10000);
+    esp_rom_delay_us(10000);
     gpio_set_level(_rst, 1);
     _len = 0;
     _ready = false;


### PR DESCRIPTION
## Summary
- include esp_rom_sys.h to use esp_rom_delay_us
- switch to esp_rom_delay_us in both C and C++ HAL implementations
