### PR TITLE
Fix clang-format violations

### DIFF
--- a/src/BNO085.cpp
+++ b/src/BNO085.cpp
@@ -72,8 +72,7 @@ bool BNO085::begin(IBNO085Transport *transport) {
 /**
  * @brief Enable periodic reporting for a sensor.
  */
-bool BNO085::enableSensor(BNO085Sensor sensor, uint32_t intervalMs,
-                          float sensitivity) {
+bool BNO085::enableSensor(BNO085Sensor sensor, uint32_t intervalMs, float sensitivity) {
   if (!initialized)
     return false;
   uint32_t intervalUs = intervalMs * 1000;
@@ -98,9 +97,7 @@ void BNO085::setCallback(SensorCallback cb) { callback = cb; }
 void BNO085::setRvcCallback(RvcCallback cb) { rvcCb = cb; }
 
 /** Check if new data is available for a sensor. */
-bool BNO085::hasNewData(BNO085Sensor sensor) const {
-  return newFlag[static_cast<uint8_t>(sensor)];
-}
+bool BNO085::hasNewData(BNO085Sensor sensor) const { return newFlag[static_cast<uint8_t>(sensor)]; }
 
 /** Retrieve the most recent event for a sensor. */
 SensorEvent BNO085::getLatest(BNO085Sensor sensor) const {
@@ -253,16 +250,15 @@ void BNO085::handleAsyncEvent(const sh2_AsyncEvent_t *event) {
   if (event->eventId == SH2_RESET) {
     for (uint8_t id = 0; id < lastInterval.size(); ++id) {
       if (lastInterval[id]) {
-        configure(static_cast<BNO085Sensor>(id), lastInterval[id],
-                  lastSensitivity[id], 0);
+        configure(static_cast<BNO085Sensor>(id), lastInterval[id], lastSensitivity[id], 0);
       }
     }
   }
 }
 
 /// @private Configure a report in the SH-2 driver
-bool BNO085::configure(BNO085Sensor sensor, uint32_t intervalUs,
-                       float sensitivity, uint32_t batchUs) {
+bool BNO085::configure(BNO085Sensor sensor, uint32_t intervalUs, float sensitivity,
+                       uint32_t batchUs) {
   sh2_SensorConfig_t cfg{};
   cfg.reportInterval_us = intervalUs;
   cfg.batchInterval_us = batchUs;

--- a/src/BNO085.hpp
+++ b/src/BNO085.hpp
@@ -155,8 +155,7 @@ public:
    * @param intervalMs Desired report interval in milliseconds.
    * @param sensitivity Change sensitivity for on-change sensors.
    */
-  bool enableSensor(BNO085Sensor sensor, uint32_t intervalMs,
-                    float sensitivity = 0.0f);
+  bool enableSensor(BNO085Sensor sensor, uint32_t intervalMs, float sensitivity = 0.0f);
   /** Disable reporting for a sensor. */
   bool disableSensor(BNO085Sensor sensor);
 
@@ -241,8 +240,7 @@ private:
 
   void handleSensorEvent(const sh2_SensorEvent_t *event);
   void handleAsyncEvent(const sh2_AsyncEvent_t *event);
-  bool configure(BNO085Sensor sensor, uint32_t intervalUs, float sensitivity,
-                 uint32_t batchUs = 0);
+  bool configure(BNO085Sensor sensor, uint32_t intervalUs, float sensitivity, uint32_t batchUs = 0);
 
   IBNO085Transport *io{nullptr};
   SensorCallback callback{};


### PR DESCRIPTION
## Summary
- run clang-format on `src/BNO085.hpp` and `src/BNO085.cpp`

## Testing
- `clang-format --dry-run --Werror src/*.hpp src/*.cpp examples/esp32/main/*.cpp`


------
https://chatgpt.com/codex/tasks/task_e_685074a17d608328866baced042b0f05